### PR TITLE
Removes Deref and AsRef impls for Database and Collection

### DIFF
--- a/examples/collection.rs
+++ b/examples/collection.rs
@@ -64,7 +64,7 @@ fn code() -> Result<(), Box<Error>> {
         // Each Cosmos' database contains so or more collections. We can enumerate them using the
         // list_collection method.
         for db in databases {
-            v.push(client.list_collections(&db).map(move |collections| {
+            v.push(client.list_collections(&db.id).map(move |collections| {
                 println!("database {} has {} collection(s)", db.id, collections.len());
 
                 for collection in collections {

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub enum KeyKind {
     Hash,
@@ -110,19 +108,5 @@ impl Collection {
             udfs: "".to_owned(),
             conflicts: "".to_owned(),
         }
-    }
-}
-
-impl Deref for Collection {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        &self.id
-    }
-}
-
-impl AsRef<str> for Collection {
-    fn as_ref(&self) -> &str {
-        &self.id
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Database {
     pub id: String,
@@ -15,18 +13,4 @@ pub struct Database {
     pub colls: String,
     #[serde(rename = "_users")]
     pub users: String,
-}
-
-impl Deref for Database {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        &self.id
-    }
-}
-
-impl AsRef<str> for Database {
-    fn as_ref(&self) -> &str {
-        &self.id
-    }
 }


### PR DESCRIPTION
Per API guidelines Deref should not be implemented on Database or Collection: https://rust-lang-nursery.github.io/api-guidelines/predictability.html#only-smart-pointers-implement-deref-and-derefmut-c-deref

Also I think AsRef<str> is also misleading here as whole struct with a number of fields is reduced to str for id. I think methods on `Client` should be made to accept both id and object (e.g. through compatible custom struct `DatabaseId` + impls of `From<&'a str>` and `From<&'a Database>` in the future.